### PR TITLE
support custom plugin sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ vagrant plugins.
 - `:version`: version of the plugin to installed, must be specified as
   a string, e.g., "1.0.2"
 - `:user`: a user to run plugin installation as. Usually this is for single user systems (like workstations).
+- `:sources`: alternate locations to search for plugins. This would commonly
+  be used if you are hosting your vagrant plugins in a custom gem repo
 
 ### Examples
 
@@ -80,6 +82,7 @@ vagrant plugins.
 
     vagrant_plugin "vagrant-berkshelf"
       version "1.2.0"
+      sources ["http://src1.example.com", "http://src2.example.com"]
     end
 
     # Install the plugins as the `donuts` user, into ~donuts/.vagrant.d

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -23,6 +23,14 @@ action :install do
   unless installed?
     plugin_args = ""
     plugin_args += "--plugin-version #{new_resource.version}" if new_resource.version
+
+    unless new_resource.sources.empty?
+      sources = Array(new_resource.sources)
+      sources.each do |source|
+        plugin_args += " --plugin-source #{source}"
+      end
+    end
+
     execute "installing vagrant plugin #{new_resource.plugin_name}" do
       command "vagrant plugin install #{new_resource.plugin_name} #{plugin_args}"
       user new_resource.user

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -7,3 +7,4 @@ attribute :version, :kind_of => [String]
 attribute :installed, :kind_of => [TrueClass, FalseClass]
 attribute :installed_version, :kind_of => [String]
 attribute :user, :kind_of => [String], :default => nil
+attribute :sources, :kind_of => [String, Array], :default => ''


### PR DESCRIPTION
In some organizations they may have developed their own custom vagrant plugins that are not available on rubygems.org. This will allow users to pass alternate source locations to look for plugins.

The new attribute will support an Array to support an admittedly limited edge case. That edge case is where the plugin is in one custom source, but depends on some other internally developed gem which lives in a different gem repository. 