### PR TITLE
Implement user-specific plugin installation

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,6 +23,7 @@ suites:
 - name: debian
   run_list:
     - recipe[vagrant]
+    - recipe[test]
   excludes:
     - centos-6.5
     - macosx-10.9
@@ -34,6 +35,7 @@ suites:
 - name: rhel
   run_list:
     - recipe[vagrant]
+    - recipe[test]
   excludes:
     - ubuntu-14.04
     - debian-7.6
@@ -46,6 +48,7 @@ suites:
 - name: osx
   run_list:
     - recipe[vagrant]
+    - recipe[test]
   excludes:
     - ubuntu-14.04
     - debian-7.6

--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,7 @@
-site :opscode
+source 'https://supermarket.chef.io'
+
 metadata
+
+group :integration do
+  cookbook 'test', :path => './test/fixtures/cookbooks/test'
+end

--- a/README.md
+++ b/README.md
@@ -1,41 +1,40 @@
-vagrant Cookbook
-================
+# vagrant Cookbook
 
-Installs Vagrant 1.6+ and manages vagrant plugins w/ a custom
-resource.
+Installs Vagrant 1.6+ and manages vagrant plugins w/ a custom resource.
 
 * Vagrant: http://www.vagrantup.com/
 
-This cookbook is not intended to be used for vagrant "1.0" (gem
-install) versions. A recipe is provided for removing the gem, see __Recipes__.
+This cookbook is not intended to be used for vagrant "1.0" (gem install) versions. A recipe is provided for removing the gem, see __Recipes__.
 
 This cookbook is not supported for installing versions of Vagrant older than 1.6.
 
-Requirements
-------------
+# Requirements
 
 Tested with Test Kitchen:
 
 * Debian 7.6
 * Ubuntu 14.04
 * CentOS 6.5
+* OS X 10.9
 
 May work on other Debian/RHEL family distributions with or without modification.
 
-Support exists for Windows and OS X but this has not yet been added to test-kitchen (`.kitchen.yml`).
+Support exists for Windows but this has not yet been added to test-kitchen. OS X support is in test-kitchen, but requires a custom box be created.
 
 The URL and Checksum attributes must be set, see __Attributes__
 
 Because Vagrant is installed as a native system package, Chef must run as a privileged user (e.g., root).
 
-Attributes
-==========
+# Attributes
 
-The following attributes *must* be set. See `.kitchen.yml` for example values.
+The following attributes *must* be set. The cookbook has helper methods in `libraries` that attempt to automatically discover these values.
 
+* `node['vagrant']['version']` - Version of Vagrant to use, default is 1.6.5, which was current at the time of writing.
 * `node['vagrant']['url']` - URL to the Vagrant installation package.
 * `node['vagrant']['checksum']` - SHA256 checksum of the Vagrant
   installation package.
+
+**Note**: I'm not taking pull requests to merely update the version. Change it in your local setup via role, environment, wrapper cookbook, etc. The helpers should take care of the rest. If a new version of vagrant requires other changes, then open an issue.
 
 If the node is Windows, the MSI version must be set. This is used by
 the `windows_package` resource to determine if the package is
@@ -44,17 +43,17 @@ installed.
 * `node['vagrant']['msi_version']` - Version string of the installed
   MSI "package" on Windows.
 
-The following attribute is optional.
+The following attributes are optional.
 
-* `node['vagrant']['plugins']` - An array of plugins. The elements in
+* `node['vagrant']['plugins']` - A array of plugins. The elements in
   the array can be a string or a hash. String elements should be the
   names of plugins to install. Hash elements should have two keys,
   "name" and "version", for the plugin name and its version to
   install. This is used by the `vagrant_plugin` resource in the
-  default recipe.
+  `install_plugins` recipe.
+* `node['vagrant']['user']` - A user that is used to automatically install plugins as for the `node['vagrant']['plugins']` attribute.
 
-Resources
-=========
+# Resources
 
 This cookbook includes the `vagrant_plugin` resource, for managing
 vagrant plugins.
@@ -73,6 +72,7 @@ vagrant plugins.
   "vagrant-omnibus".
 - `:version`: version of the plugin to installed, must be specified as
   a string, e.g., "1.0.2"
+- `:user`: a user to run plugin installation as. Usually this is for single user systems (like workstations).
 
 ### Examples
 
@@ -82,15 +82,21 @@ vagrant plugins.
       version "1.2.0"
     end
 
-Recipes
-=======
+    # Install the plugins as the `donuts` user, into ~donuts/.vagrant.d
+    vagrant_plugin "vagrant-aws"
+      user "donuts"
+    end
+
+# Recipes
 
 ## default
 
 The default recipe includes the platform-family specific recipe to
-install Vagrant. It then iterates over the
-`node['vagrant']['plugins']` attribute to install any required vagrant
-plugins.
+install Vagrant. If the `node['vagrant']['plugins']` attribute is not empty, it includes the install_plugins recipe to install any required vagrant plugins.
+
+## install_plugins
+
+Iterates over the `node['vagrant']['plugins']` attribute and installs the listed plugins. If that attribute is a hash, it uses the version. If the `node['vagrant']['user']` attribute is set, the plugins are installed for only that user.
 
 ## debian, fedora, mac_os_x, rhel, windows
 
@@ -109,11 +115,10 @@ running `rbenv rehash`. Likewise, if you have multiple copies of the
 vagrant gem installed, you'll need to clean up all versions. This
 recipe won't support such craziness :-).
 
-Usage
-=====
+# Usage
 
 Set the url and checksum attributes on the node. Do this in a role, or
-a "wrapper" cookbook.
+a "wrapper" cookbook. Or, just set the version and let the magic happen.
 
 Then include the default recipe on the node's run list.
 
@@ -129,12 +134,12 @@ of the `vagrant-berkshelf` plugin:
 
 See the attribute description above.
 
-License and Authors
--------------------
+# License and Authors
 
 * Author:: Joshua Timberman <opensource@housepub.org>
 * Copyright (c) 2013-2014, Joshua Timberman
 
+```
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
@@ -146,3 +151,4 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
+```

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,4 +20,5 @@ default['vagrant']['version']     = '1.6.5'
 default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
 default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
 default['vagrant']['plugins']     = []
+default['vagrant']['user']        = nil
 default['vagrant']['msi_version'] = ''

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -48,3 +48,26 @@ end
 def vagrant_package_uri(vers = nil)
   URI.join(vagrant_base_uri, vagrant_platform_package(vers)).to_s
 end
+
+def vagrant_get_home(user)
+  begin
+    # Attempting to get the $HOME of `user`
+    Chef::Log.debug("Attempting to get $HOME of #{user}")
+    home = Etc.getpwnam(user).dir
+  rescue ArgumentError
+    begin
+      # Could not look up `user`, seeing if Chef knows about a
+      # user[`user`] resource
+      Chef::Log.debug("Couldn't find `#{user}`, looking for a resource")
+      home = resources("user[#{user}]").home
+    rescue Chef::Exceptions::ResourceNotFound
+      # Chef does not know about a user[`user`] resource, and that
+      # user does not exist on the system, try using the $HOME of the
+      # user running Chef
+      Chef::Log.debug("No user found, using running process uid, `#{Process.uid}`")
+      home = Etc.getpwuid(Process.uid).dir
+    end
+  end
+
+  home
+end

--- a/recipes/install_plugins.rb
+++ b/recipes/install_plugins.rb
@@ -17,5 +17,19 @@
 # limitations under the License.
 #
 
-include_recipe "vagrant::#{node['platform_family']}"
-include_recipe 'vagrant::install_plugins' if node['vagrant']['plugins'].length > 0
+node['vagrant']['plugins'].each do |plugin|
+  if plugin.respond_to?(:keys)
+
+    vagrant_plugin plugin['name'] do
+      user node['vagrant']['user']
+      version plugin['version']
+    end
+
+  else
+
+    vagrant_plugin plugin do
+      user node['vagrant']['user']
+    end
+
+  end
+end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -6,3 +6,4 @@ attribute :plugin_name, :name_attribute => true
 attribute :version, :kind_of => [String]
 attribute :installed, :kind_of => [TrueClass, FalseClass]
 attribute :installed_version, :kind_of => [String]
+attribute :user, :kind_of => [String], :default => nil

--- a/test/fixtures/cookbooks/test/README.md
+++ b/test/fixtures/cookbooks/test/README.md
@@ -1,0 +1,4 @@
+# test
+
+This cookbook is used for testing the `vagrant` cookbook.
+

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,0 +1,3 @@
+name             'test'
+version          '0.1.0'
+

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,0 +1,18 @@
+# How meta...
+vagrant_plugin 'vagrant-aws' do
+  user 'vagrant'
+end
+
+# A user that doesn't exist...
+user 'donuts' do
+  shell '/bin/bash'
+  home '/home/donuts'
+  supports :manage_home => true
+end
+
+# And a version of vagrant-aws not used previously in this run, just
+# to be sure.
+vagrant_plugin 'vagrant-aws' do
+  version '0.4.1'
+  user 'donuts'
+end


### PR DESCRIPTION
This commit implements the oft-requested user-specific plugin installation.
This resolves the pull requests: #2, #4, #8.

A huge thank you goes out to everyone who took the time to open these
pull requests, and participate in discussion on them. Thank you:
@patcon, @hugofonseca, @sneal, @kowal, @pwelch, @oker1, @adamjk-dev,
@amferraz, @englishm, and @arangamani. My apologies for terse
responses and lack of action/decision on this for so long. 

Notable changes:

Add a test cookbook that implements two scenarios of plugin installation. The
first is for a user that will exist in a test-kitchen environment - vagrant.
The second is for a user created during the chef run itself, to prove we can
look up the user and get the right home directory.

A new `user` attribute, which is a "global" default if using the plugins
attribute to install a list of plugins. This assumes a single user will have
vagrant plugins. Consumers of this cookbook with multiple users that have
vagrant installations on a single system will need to implement their own
recipes.

Add a helper method, `vagrant_get_home`, that attempts to be smart about
detecting the user for plugin installation.

Refactor the provider actions to use `execute` resources (and add
`use_inline_resources`). This gives us the benefit of built-in
`converge_by`, and thus why-run support. It also makes the action blocks
easier to read.

Move the plugin installation loop out of the default recipe and into its own
recipe. This gives consumers flexibility, and decouples the functionality.