### PR TITLE
Support RHEL platforms

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -32,7 +32,7 @@ def vagrant_platform_package(vers = nil)
     case node['platform_family']
     when 'debian'
       "vagrant_#{vers}_x86_64.deb"
-    when 'redhat', 'fedora'
+    when 'redhat', 'fedora', 'rhel'
       "vagrant_#{vers}_x86_64.rpm"
     end
   end

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,6 +9,7 @@ version          '0.2.1'
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 12.04'
 supports 'redhat', '>= 6.3'
+supports 'centos', '>= 6.4'
 
 depends "dmg"
 depends "windows"


### PR DESCRIPTION
On CentOS `node['platform_family']` returns `rhel` and that was not supported by the library.