### PR TITLE
Update vagrant version to 1.7.2, Fix centos converge

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,2 +1,2 @@
-site :opscode
+source "https://supermarket.chef.io"
 metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0:
+
+* Update vagrant to the 1.7.2 version (from 1.6.5)
+* Change platform_family check from "redhat" to "rhel"
+  to make `kitchen converge centos` correctly complete.
+
 ## 0.2.0:
 
 * Add `uninstall_gem` recipe to remove vagrant (1.0) gem.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,7 +16,7 @@
 # limitations under the License.
 #
 
-default['vagrant']['version']     = '1.6.5'
+default['vagrant']['version']     = '1.7.2'
 default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
 default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
 default['vagrant']['plugins']     = []

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,18 +23,15 @@ def vagrant_base_uri
 end
 
 def vagrant_platform_package(vers = nil)
-  case node['os']
-  when 'darwin'
+  case node['platform_family']
+  when 'mac_os_x'
     "vagrant_#{vers}.dmg"
   when 'windows'
     "vagrant_#{vers}.msi"
-  when 'linux'
-    case node['platform_family']
-    when 'debian'
-      "vagrant_#{vers}_x86_64.deb"
-    when 'redhat', 'fedora'
-      "vagrant_#{vers}_x86_64.rpm"
-    end
+  when 'debian'
+    "vagrant_#{vers}_x86_64.deb"
+  when 'rhel', 'fedora'
+    "vagrant_#{vers}_x86_64.rpm"
   end
 end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@housepub.org'
 license          'Apache 2.0'
 description      'Installs/Configures vagrant'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.3.0'
 
 supports 'debian', '>= 6.0'
 supports 'ubuntu', '>= 12.04'


### PR DESCRIPTION
Update berksfile to support berkshelf-api source URL
Fix kitchen converge for centos.  The ohai value for platform_family appears to have changed from "redhat" to "rhel".
Update vagrant version to 1.7.2, minor version bump