### PR TITLE
Fixed platform detection

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,10 @@
 #
 
 default['vagrant']['version']     = '1.6.5'
-default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
-default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
+if %w(darwin windows linux).include? node['os']
+  default['vagrant']['url']       = vagrant_package_uri(node['vagrant']['version'])
+  default['vagrant']['checksum']  = vagrant_sha256sum(node['vagrant']['version'])
+end
 default['vagrant']['plugins']     = []
 default['vagrant']['user']        = nil
 default['vagrant']['msi_version'] = ''

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -32,7 +32,7 @@ def vagrant_platform_package(vers = nil)
     case node['platform_family']
     when 'debian'
       "vagrant_#{vers}_x86_64.deb"
-    when 'fedora', 'rhel'
+    when 'fedora', 'rhel', 'suse'
       "vagrant_#{vers}_x86_64.rpm"
     end
   end


### PR DESCRIPTION
This cookbook will not compile on SUSE, so it breaks the Chef run even if Vagrant is not used on SUSE.

```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/vagrant/attributes/default.rb
================================================================================

ArgumentError
-------------
bad argument (expected URI object or URI string)

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/vagrant/libraries/helpers.rb:49:in `vagrant_package_uri'
  /var/chef/cache/cookbooks/vagrant/attributes/default.rb:20:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/vagrant/libraries/helpers.rb:

 42:    # fetch the version-specific sha256sum file
 43:    # grep for the platform-specific package name
 44:    sha256sums = open(URI.join(vagrant_base_uri, "#{vers}_SHA256SUMS?direct"))
 45:    sha256sums.readlines.grep(/#{vagrant_platform_package(vers)}/)[0].split.first
 46:  end
 47:
 48:  def vagrant_package_uri(vers = nil)
 49>>   URI.join(vagrant_base_uri, vagrant_platform_package(vers)).to_s
 50:  end
 51:
```