### PR TITLE
Improve multiplatform support

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -21,8 +21,6 @@ platforms:
 suites:
 - name: debian
   run_list:
-    - recipe[build-essential]
-    - recipe[vagrant]
     - recipe[test]
   excludes:
     - centos-6.6
@@ -34,8 +32,6 @@ suites:
 
 - name: rhel
   run_list:
-    - recipe[build-essential]
-    - recipe[vagrant]
     - recipe[test]
   excludes:
     - ubuntu-14.04
@@ -47,8 +43,6 @@ suites:
 
 - name: osx
   run_list:
-    - recipe[build-essential]
-    - recipe[vagrant]
     - recipe[test]
   excludes:
     - ubuntu-14.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,16 +8,15 @@ provisioner:
   name: chef_zero
 
 platforms:
-- name: debian-7.6
+# We don't have every platform that this might work on, or every
+# version as the latest. The behavior in this cookbook is dependent on
+# platform families.
 - name: ubuntu-14.04
-- name: centos-6.5
-  # To run test-kitchen for OS X, create a box for 10.9, and add it to
-  # vagrant. See for example,
-  # https://github.com/timsutton/osx-vm-templates
-  # https://github.com/opscode/bento/blob/master/packer/macosx-10.9.json
-- name: macosx-10.9
+- name: centos-6.6
+  # To run test-kitchen for OS X, create a box for 10.10, and add it to vagrant
+- name: macosx-10.10
   driver:
-    box: chef/macosx-10.9
+    box: chef/macosx-10.10
 
 suites:
 - name: debian
@@ -26,8 +25,8 @@ suites:
     - recipe[vagrant]
     - recipe[test]
   excludes:
-    - centos-6.5
-    - macosx-10.9
+    - centos-6.6
+    - macosx-10.10
   attributes:
     vagrant:
       plugins:
@@ -40,8 +39,7 @@ suites:
     - recipe[test]
   excludes:
     - ubuntu-14.04
-    - debian-7.6
-    - macosx-10.9
+    - macosx-10.10
   attributes:
     vagrant:
       plugins:
@@ -54,8 +52,7 @@ suites:
     - recipe[test]
   excludes:
     - ubuntu-14.04
-    - debian-7.6
-    - centos-6.5
+    - centos-6.6
   attributes:
     vagrant:
       plugins:

--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,1 @@
+.kitchen

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -32,9 +32,13 @@ def vagrant_platform_package(vers = nil)
     case node['platform_family']
     when 'debian'
       "vagrant_#{vers}_x86_64.deb"
-    when 'fedora', 'rhel'
+    when 'fedora', 'rhel', 'suse'
+      Chef::Log.debug 'SUSE is not specifically supported by vagrant, going to try anyway as if we were RHEL (rpm install).' if platform_family?('suse')
       "vagrant_#{vers}_x86_64.rpm"
     end
+  else
+    Chef::Log.warn "#{node['platform']} is not supported by vagrant."
+    return
   end
 end
 
@@ -59,7 +63,7 @@ def vagrant_get_home(user)
       # Could not look up `user`, seeing if Chef knows about a
       # user[`user`] resource
       Chef::Log.debug("Couldn't find `#{user}`, looking for a resource")
-      home = resources("user[#{user}]").home
+      home = run_context.resource_collection.find("user[#{user}]").home
     rescue Chef::Exceptions::ResourceNotFound
       # Chef does not know about a user[`user`] resource, and that
       # user does not exist on the system, try using the $HOME of the

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,5 +12,5 @@ supports 'centos', '>= 6.4'
 supports 'windows'
 supports 'mac_os_x'
 
-depends 'dmg'
-depends 'windows'
+depends 'dmg', '>= 2.2.2'
+depends 'windows', '>= 1.30.2'

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -55,7 +55,19 @@ def uninstall
 end
 
 def run_as_user
-  new_resource.user || Etc.getpwuid(Process.uid).name
+  case new_resource.user
+  when String
+    Chef::Log.debug("I found a string for `#{new_resource.user}`")
+    new_resource.user
+  when NilClass
+    begin
+      Chef::Log.debug("I'm searching for a resource user[#{new_resource.user}]")
+      run_context.resource_collection.find("user[#{new_resource.user}]").username
+    rescue ArgumentError
+      Chef::Log.debug("Trying to find the user by the process UID #{Process.uid}")
+      Etc.getpwuid(Process.uid).name
+    end
+  end
 end
 
 def vagrant_home

--- a/recipes/suse.rb
+++ b/recipes/suse.rb
@@ -1,0 +1,3 @@
+Chef::Log.debug 'SUSE is not specifically supported by vagrant, going to try anyway as if we were RHEL (rpm install).' if platform_family?('suse')
+
+include_recipe 'vagrant::rhel'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require 'chefspec'
+require 'chefspec/berkshelf'

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -1,0 +1,173 @@
+# Author:: Joshua Timberman <opensource@housepub.org>
+# Copyright:: Copyright (c) 2014, Joshua Timberman
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'spec_helper'
+
+describe 'vagrant::default' do
+  before(:each) do
+    allow_any_instance_of(Chef::Node).to receive(:vagrant_sha256sum).and_return('')
+  end
+
+  context 'debian' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'ubuntu',
+        version: '14.04',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the debian platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::debian')
+    end
+
+    it 'downloads the package from the calculated URI' do
+      expect(chef_run).to create_remote_file('/var/tmp/vagrant.deb').with(
+        source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.deb'
+      )
+    end
+
+    it 'installs the downloaded package' do
+      expect(chef_run).to install_dpkg_package('vagrant').with(
+        source: '/var/tmp/vagrant.deb'
+      )
+    end
+  end
+
+  context 'fedora' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'fedora',
+        version: '21',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the rhel platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::rhel')
+    end
+
+    it 'downloads the package from the calculated URI' do
+      expect(chef_run).to create_remote_file('/var/tmp/vagrant.rpm').with(
+        source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.rpm'
+      )
+    end
+
+    it 'installs the downloaded package' do
+      expect(chef_run).to install_rpm_package('vagrant').with(
+        source: '/var/tmp/vagrant.rpm'
+      )
+    end
+  end
+
+  context 'rhel' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'centos',
+        version: '6.6',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the rhel platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::rhel')
+    end
+
+    it 'downloads the package from the calculated URI' do
+      expect(chef_run).to create_remote_file('/var/tmp/vagrant.rpm').with(
+        source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.rpm'
+      )
+    end
+
+    it 'installs the downloaded package' do
+      expect(chef_run).to install_rpm_package('vagrant').with(
+        source: '/var/tmp/vagrant.rpm'
+      )
+    end
+  end
+
+  context 'suse' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'suse',
+        version: '12.0',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the rhel platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::rhel')
+    end
+
+    it 'downloads the package from the calculated URI' do
+      expect(chef_run).to create_remote_file('/var/tmp/vagrant.rpm').with(
+        source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.rpm'
+      )
+    end
+
+    it 'installs the downloaded package' do
+      expect(chef_run).to install_rpm_package('vagrant').with(
+        source: '/var/tmp/vagrant.rpm'
+      )
+    end
+  end
+
+  context 'os x' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'mac_os_x',
+        version: '10.10',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the os x platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::mac_os_x')
+    end
+
+    it 'installs the downloaded package with the calculated source URI' do
+      expect(chef_run).to install_dmg_package('Vagrant').with(
+        source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88.dmg'
+      )
+    end
+  end
+
+  context 'windows' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(
+        platform: 'windows',
+        version: '2012',
+        file_cache_path: '/var/tmp'
+      ) do |node|
+        node.set['vagrant']['version'] = '1.88.88'
+      end.converge(described_recipe)
+    end
+
+    it 'includes the windows platform family recipe' do
+      expect(chef_run).to include_recipe('vagrant::windows')
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/metadata.rb
+++ b/test/fixtures/cookbooks/test/metadata.rb
@@ -1,2 +1,4 @@
-name             'test'
-version          '0.1.0'
+name    'test'
+version '0.1.0'
+depends 'build-essential'
+depends 'vagrant'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,3 +1,8 @@
+execute 'apt-get update' if platform_family?('debian')
+
+include_recipe 'build-essential'
+include_recipe 'vagrant'
+
 # How meta...
 vagrant_plugin 'vagrant-aws' do
   user 'vagrant'

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -4,15 +4,31 @@ vagrant_plugin 'vagrant-aws' do
 end
 
 # A user that doesn't exist...
+donut_home = case node['os']
+             when 'darwin' then '/Users/donuts'
+             when 'linux' then '/home/donuts'
+               # untested, this is run in test kitchen, but i don't have a
+               # current windows box
+             when 'windows' then 'C:/Users/donuts'
+             end
+
 user 'donuts' do
+  uid '777'
+  gid 'staff' if ['darwin'].include?(node['os'])
   shell '/bin/bash'
-  home '/home/donuts'
+  home donut_home
   supports :manage_home => true
 end
 
-# And a version of vagrant-aws not used previously in this run, just
-# to be sure.
-vagrant_plugin 'vagrant-aws' do
-  version '0.4.1'
+directory donut_home do
+  owner 'donuts'
+  group 'staff' if ['darwin'].include?(node['os'])
+  recursive true
+end
+
+# Use a different plugin for the donuts user. This doesn't work on OS
+# X though, getting a permission problem on installing ffi.
+vagrant_plugin 'vagrant-ohai' do
+  version '0.1.12'
   user 'donuts'
 end


### PR DESCRIPTION
* Update kitchen with platforms to test upon
* YOLO for SUSE, may "just work" using the RHEL rpm
* Exit gracefully on unsupported platforms
* Ensure dmg and windows cookbook dependencies use adequate versions
* Try better handling for user-specific plugins. Does not work reliably
  on OS X though.
* Add a default recipe spec