### PR TITLE
Avoid compilation errors on unsupported platforms

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,8 +17,10 @@
 #
 
 default['vagrant']['version']     = '1.6.5'
-default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
-default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
+if %w(darwin windows linux).include? node['os']
+  default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
+  default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
+end
 default['vagrant']['plugins']     = []
 default['vagrant']['user']        = nil
 default['vagrant']['msi_version'] = ''


### PR DESCRIPTION
This cookbook will not compile on unsupported platforms, e.g. AIX or Solaris. That's a problem even if the cookbook is not used, since it must be compiled as a transitive dependency of some other cookbook.

```
Compiling Cookbooks...

================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/vagrant/attributes/default.rb
================================================================================

ArgumentError
-------------
bad argument (expected URI object or URI string)

Cookbook Trace:
---------------
  /var/chef/cache/cookbooks/vagrant/libraries/helpers.rb:53:in `vagrant_package_uri'
  /var/chef/cache/cookbooks/vagrant/attributes/default.rb:20:in `from_file'

Relevant File Content:
----------------------
/var/chef/cache/cookbooks/vagrant/libraries/helpers.rb:

 46:    # fetch the version-specific sha256sum file
 47:    # grep for the platform-specific package name
 48:    sha256sums = open(URI.join(vagrant_base_uri, "#{vers}_SHA256SUMS?direct"))
 49:    sha256sums.readlines.grep(/#{vagrant_platform_package(vers)}/)[0].split.first
 50:  end
 51:
 52:  def vagrant_package_uri(vers = nil)
 53>>   URI.join(vagrant_base_uri, vagrant_platform_package(vers)).to_s
 54:  end
 55:
 56:  def vagrant_get_home(user)
 57:    begin
 58:      # Attempting to get the $HOME of `user`
 59:      Chef::Log.debug("Attempting to get $HOME of #{user}")
 60:      home = Etc.getpwnam(user).dir
 61:    rescue ArgumentError
 62:      begin
```