### PR TITLE
Add Rakefile for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Add ChefSpec [Custom Matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers)
 for `vagrant_plugin`.
+* Add Rakefile for testing/style checks.
 
 ## 0.3.1:
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,13 @@
 # Cookbook Name:: vagrant
-# Recipe:: fedora
+# Rakefile
 
-# Author:: Joshua Timberman <opensource@housepub.org>
-# Copyright:: Copyright (c) 2014, Joshua Timberman
-# License:: Apache License, Version 2.0
+# Copyright 2015 Joshua Timberman
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,4 +15,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'vagrant::rhel'
+require 'rubocop/rake_task'
+require 'foodcritic'
+require 'rspec/core/rake_task'
+
+RuboCop::RakeTask.new do |rubocop|
+  rubocop.options = ['-D']
+end
+
+FoodCritic::Rake::LintTask.new
+
+RSpec::Core::RakeTask.new
+
+desc 'Run Rubocop and Foodcritic style checks'
+task style: [:rubocop, :foodcritic]
+
+desc 'Run all style checks and unit tests'
+task test: [:style, :spec]
+
+task default: :test

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,25 +1,31 @@
-This cookbook includes support for running tests via Test Kitchen (1.0). This has some requirements.
+# Testing
 
-1. You must be using the Git repository, rather than the downloaded cookbook from the Chef Community Site.
-2. You must have Vagrant 1.1+ installed.
-3. You must have a "sane" Ruby 1.9.3 environment.
+## Style and Unit Testing
+This cookbook comes with a Rakefile with the following testing targets:
 
-Once the above requirements are met, install the additional requirements:
+```
+rake foodcritic            # Lint Chef cookbooks
+rake rubocop               # Run RuboCop
+rake rubocop:auto_correct  # Auto-correct RuboCop offenses
+rake spec                  # Run RSpec code examples
+rake style                 # Run Rubocop and Foodcritic style checks
+rake test                  # Run style checks and unit tests
+```
 
-Install the berkshelf plugin for vagrant, and berkshelf to your local Ruby environment.
+## Integration (test-kitchen)
+A .kitchen.yml file is also provided.
 
-    vagrant plugin install vagrant-berkshelf
-    gem install berkshelf
+To run test-kitchen on a Mac guest, you will need to provide a Mac vagrant box.
 
-Install Test Kitchen 1.0 (unreleased yet, use the alpha / prerelease version).
+```
+kitchen list
 
-    gem install test-kitchen --pre
+Instance            Driver   Provisioner  Verifier  Transport  Last Action
+debian-ubuntu-1404  Vagrant  ChefZero     Busser    Ssh        <Not Created>
+rhel-centos-71      Vagrant  ChefZero     Busser    Ssh        <Not Created>
+osx-macosx-1010     Vagrant  ChefZero     Busser    Ssh        <Not Created>
+```
 
-Install the Vagrant driver for Test Kitchen.
-
-    gem install kitchen-vagrant
-
-Once the above are installed, you should be able to run Test Kitchen:
-
-    kitchen list
-    kitchen test
+```
+kitchen test
+```


### PR DESCRIPTION
This change provides a consistent interface for running local tests (Rake).
It also paves the way for this cookbook to be tested in Travis-CI which
expects to run Rake tasks for Ruby projects like Chef cookbooks.