### PR TITLE
Fix Vagrant package install on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+# Vagrant Cookbook Changelog
+
 ## Unreleased
 
 * Add ChefSpec [Custom Matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers)
 for `vagrant_plugin`.
 * Add Rakefile for testing/style checks.
+* Fix idempotency when installing Vagrant Windows package.
+* Bump default Vagrant version to 1.7.4
 
 ## 0.3.1:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Because Vagrant is installed as a native system package, Chef must run as a priv
 
 The following attributes *must* be set. The cookbook has helper methods in `libraries` that attempt to automatically discover these values.
 
-* `node['vagrant']['version']` - Version of Vagrant to use, default is 1.6.5, which was current at the time of writing.
+* `node['vagrant']['version']` - Version of Vagrant to use, default is 1.7.4, which was current at the time of writing.
 * `node['vagrant']['url']` - URL to the Vagrant installation package.
 * `node['vagrant']['checksum']` - SHA256 checksum of the Vagrant
   installation package.

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,9 +19,10 @@
 #
 return unless %w(darwin windows linux).include?(node['os'])
 
-default['vagrant']['version']     = '1.6.5'
+default['vagrant']['version']     = '1.7.4'
+default['vagrant']['msi_version'] = '1.7.4'
+
 default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
 default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
 default['vagrant']['plugins']     = []
 default['vagrant']['user']        = nil
-default['vagrant']['msi_version'] = ''

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -15,8 +15,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-windows_package "Vagrant #{node['vagrant']['msi_version']}" do
+windows_package 'Vagrant' do
+  action :install
+  version node['vagrant']['msi_version']
   source node['vagrant']['url']
   checksum node['vagrant']['checksum']
-  action :install
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -16,7 +16,7 @@
 #
 require 'spec_helper'
 
-describe 'vagrant::default' do
+RSpec.describe 'vagrant::default' do
   before(:each) do
     allow_any_instance_of(Chef::Node).to receive(:vagrant_sha256sum).and_return('')
   end

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'vagrant::windows' do
     VAGRANT_DEFAULT_VERSION = '1.7.4'
 
     cached(:windows_node) do
-      ChefSpec::ServerRunner.new(
+      ChefSpec::SoloRunner.new(
         platform: 'windows',
         version: '2012R2'
       ) do |node|
@@ -43,7 +43,7 @@ RSpec.describe 'vagrant::windows' do
   context 'when you override the version' do
     VAGRANT_OVERRIDE_VERSION = '1.88.88'
     cached(:windows_node) do
-      ChefSpec::ServerRunner.new(
+      ChefSpec::SoloRunner.new(
         platform: 'windows',
         version: '2012R2'
       ) do |node|

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -1,0 +1,62 @@
+# Author:: Doug Ireton
+# Copyright:: Copyright (c) 2015
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+RSpec.describe 'vagrant::windows' do
+  before(:each) do
+    allow_any_instance_of(Chef::Node).to receive(:vagrant_sha256sum)
+  end
+
+  context 'with default attributes' do
+    VAGRANT_DEFAULT_VERSION = '1.7.4'
+
+    cached(:windows_node) do
+      ChefSpec::ServerRunner.new(
+        platform: 'windows',
+        version: '2012R2'
+      ) do |node|
+        node.set['vagrant']['msi_version'] = VAGRANT_DEFAULT_VERSION
+      end.converge(described_recipe)
+    end
+
+    it "installs Vagrant version #{VAGRANT_DEFAULT_VERSION}" do
+      expect(windows_node).to install_windows_package('Vagrant').with(
+        source: "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{VAGRANT_DEFAULT_VERSION}.msi",
+        version: VAGRANT_DEFAULT_VERSION
+      )
+    end
+  end
+
+  context 'when you override the version' do
+    VAGRANT_OVERRIDE_VERSION = '1.88.88'
+    cached(:windows_node) do
+      ChefSpec::ServerRunner.new(
+        platform: 'windows',
+        version: '2012R2'
+      ) do |node|
+        node.set['vagrant']['version'] = VAGRANT_OVERRIDE_VERSION
+        node.set['vagrant']['msi_version'] = VAGRANT_OVERRIDE_VERSION
+      end.converge(described_recipe)
+    end
+
+    it 'installs the correct package version' do
+      expect(windows_node).to install_windows_package('Vagrant').with(
+        source: "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{VAGRANT_OVERRIDE_VERSION}.msi",
+        version: VAGRANT_OVERRIDE_VERSION
+      )
+    end
+  end
+end


### PR DESCRIPTION
Fix idempotency when installing Vagrant Windows package.
Vagrant's DisplayName in the Uninstall key in the registry is 'Vagrant',
not 'Vagrant \<version\>'.

Bump default Vagrant version to 1.7.4
https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md#174-july-17-2015