### PR TITLE
Refactor Vagrant::Helper module. Add spec coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ for `vagrant_plugin`.
 * Add Rakefile for testing/style checks.
 * Fix idempotency when installing Vagrant Windows package.
 * Bump default Vagrant version to 1.7.4
+* Refactor Vagrant::Helpers and add test coverage
+* Cookbook no longer fails during compile phase if https://dl.bintray.com is
+unavailable. You can override `node['vagrant']['url']` and
+`node['vagrant']['checksum']` if you need to download Vagrant from a different
+location.
 
 ## 0.3.1:
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -16,13 +16,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
+
 return unless %w(darwin windows linux).include?(node['os'])
 
 default['vagrant']['version']     = '1.7.4'
 default['vagrant']['msi_version'] = '1.7.4'
 
-default['vagrant']['url']         = vagrant_package_uri(node['vagrant']['version'])
-default['vagrant']['checksum']    = vagrant_sha256sum(node['vagrant']['version'])
+default['vagrant']['url']         = nil
+default['vagrant']['checksum']    = nil
 default['vagrant']['plugins']     = []
 default['vagrant']['user']        = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -16,7 +16,7 @@ name             'vagrant'
 maintainer       'Joshua Timberman'
 maintainer_email 'cookbooks@housepub.org'
 license          'Apache 2.0'
-description      'Installs vagrant'
+description      'Installs Vagrant and provides a vagrant_plugin LWRP for installing Vagrant plugins.'
 version          '0.3.1'
 
 supports 'debian', '>= 6.0'

--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -17,9 +17,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+vagrant_url = node['vagrant']['url'] || vagrant_package_uri
+vagrant_checksum = node['vagrant']['checksum'] || vagrant_sha256sum
+
 remote_file "#{Chef::Config[:file_cache_path]}/vagrant.deb" do
-  source node['vagrant']['url']
-  checksum node['vagrant']['checksum']
+  source vagrant_url
+  checksum vagrant_checksum
   notifies :install, 'dpkg_package[vagrant]', :immediately
 end
 

--- a/recipes/mac_os_x.rb
+++ b/recipes/mac_os_x.rb
@@ -14,10 +14,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+vagrant_url = node['vagrant']['url'] || vagrant_package_uri
+vagrant_checksum = node['vagrant']['checksum'] || vagrant_sha256sum
 
 dmg_package 'Vagrant' do
-  source node['vagrant']['url']
-  checksum node['vagrant']['checksum']
+  source vagrant_url
+  checksum vagrant_checksum
   type 'pkg'
   package_id 'com.vagrant.vagrant'
   action :install

--- a/recipes/rhel.rb
+++ b/recipes/rhel.rb
@@ -15,9 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+vagrant_url = node['vagrant']['url'] || vagrant_package_uri
+vagrant_checksum = node['vagrant']['checksum'] || vagrant_sha256sum
+
 remote_file "#{Chef::Config[:file_cache_path]}/vagrant.rpm" do
-  source node['vagrant']['url']
-  checksum node['vagrant']['checksum']
+  source vagrant_url
+  checksum vagrant_checksum
   notifies :install, 'rpm_package[vagrant]', :immediately
 end
 

--- a/recipes/windows.rb
+++ b/recipes/windows.rb
@@ -15,9 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+vagrant_url = node['vagrant']['url'] || vagrant_package_uri
+vagrant_checksum = node['vagrant']['checksum'] || vagrant_sha256sum
+vagrant_version = node['vagrant']['msi_version'] || node['vagrant']['version']
+
 windows_package 'Vagrant' do
   action :install
-  version node['vagrant']['msi_version']
-  source node['vagrant']['url']
-  checksum node['vagrant']['checksum']
+  version vagrant_version
+  source vagrant_url
+  checksum vagrant_checksum
 end

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require_relative '../../../libraries/helpers'
+
+RSpec.describe Vagrant::Helpers do
+  let(:my_recipe) { Class.new { extend Vagrant::Helpers } }
+  let(:checksums) do
+    [
+      '3d2e680cc206ac1d480726052e42e193eabce56ed65fc79b91bc85e4c7d2deb8  vagrant_1.7.4.dmg',
+      'a1ca7d99f162e001c826452a724341f421adfaef3e1366ee504b73ad19e3574f  vagrant_1.7.4.msi',
+      '050411ba8b36e322c4ce32990d2539e73a87fabd932f7397d2621986084eda6a  vagrant_1.7.4_i686.deb',
+      'f83ea56f8d1a37f3fdf24dd4d14bf8d15545ed0e39b4c1c5d4055f3de6eb202d  vagrant_1.7.4_i686.rpm',
+      'dcd2c2b5d7ae2183d82b8b363979901474ba8d2006410576ada89d7fa7668336  vagrant_1.7.4_x86_64.deb',
+      'b0a09f6e6f9fc17b01373ff54d1f5b0dc844394886109ef407a5f1bcfdd4e304  vagrant_1.7.4_x86_64.rpm'
+    ]
+  end
+
+  it 'returns the correct Vagrant package URL' do
+    allow(my_recipe).to receive(:package_version).and_return('1.7.4')
+    allow(my_recipe).to receive(:package_extension).and_return('.dmg')
+
+    expect(my_recipe.vagrant_package_uri).to eq 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.dmg'
+  end
+
+  it 'returns the correct SHA256 checksum for the mac_os_x package' do
+    allow(my_recipe).to receive(:package_version).and_return('1.7.4')
+    allow(my_recipe).to receive(:package_extension).and_return('.dmg')
+    allow(my_recipe).to receive(:fetch_platform_checksums_for_version).and_return(checksums)
+
+    expect(my_recipe.vagrant_sha256sum).to eq '3d2e680cc206ac1d480726052e42e193eabce56ed65fc79b91bc85e4c7d2deb8'
+  end
+
+  it 'returns the correct SHA256 checksum for the RHEL package' do
+    allow(my_recipe).to receive(:package_version).and_return('1.7.4')
+    allow(my_recipe).to receive(:package_extension).and_return('_x86_64.rpm')
+    allow(my_recipe).to receive(:fetch_platform_checksums_for_version).and_return(checksums)
+
+    expect(my_recipe.vagrant_sha256sum).to eq 'b0a09f6e6f9fc17b01373ff54d1f5b0dc844394886109ef407a5f1bcfdd4e304'
+  end
+end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -18,7 +18,8 @@ require 'spec_helper'
 
 RSpec.describe 'vagrant::default' do
   before(:each) do
-    allow_any_instance_of(Chef::Node).to receive(:vagrant_sha256sum).and_return('')
+    allow_any_instance_of(Chef::Recipe).to receive(:vagrant_sha256sum)
+      .and_return('abc123')
   end
 
   context 'debian' do
@@ -32,17 +33,17 @@ RSpec.describe 'vagrant::default' do
       end.converge(described_recipe)
     end
 
-    it 'includes the debian platform family recipe' do
+    fit 'includes the debian platform family recipe' do
       expect(chef_run).to include_recipe('vagrant::debian')
     end
 
-    it 'downloads the package from the calculated URI' do
+    fit 'downloads the package from the calculated URI' do
       expect(chef_run).to create_remote_file('/var/tmp/vagrant.deb').with(
         source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.deb'
       )
     end
 
-    it 'installs the downloaded package' do
+    fit 'installs the downloaded package' do
       expect(chef_run).to install_dpkg_package('vagrant').with(
         source: '/var/tmp/vagrant.deb'
       )

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -17,7 +17,8 @@ require 'spec_helper'
 
 RSpec.describe 'vagrant::windows' do
   before(:each) do
-    allow_any_instance_of(Chef::Node).to receive(:vagrant_sha256sum)
+    allow_any_instance_of(Chef::Recipe).to receive(:vagrant_sha256sum)
+      .and_return('abc123')
   end
 
   context 'with default attributes' do
@@ -52,7 +53,7 @@ RSpec.describe 'vagrant::windows' do
       end.converge(described_recipe)
     end
 
-    it 'installs the correct package version' do
+    it "installs Vagrant version #{VAGRANT_OVERRIDE_VERSION}" do
       expect(windows_node).to install_windows_package('Vagrant').with(
         source: "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{VAGRANT_OVERRIDE_VERSION}.msi",
         version: VAGRANT_OVERRIDE_VERSION


### PR DESCRIPTION
1. Refactor Vagrant::Helpers and add test coverage
2. Cookbook no longer fails during compile phase if https://dl.bintray.com is
unavailable. You can override `node['vagrant']['url']` and
`node['vagrant']['checksum']` if you need to download Vagrant from a different
location.

Fixes #37 