### PR TITLE
Removed unnecessary line from plugin provider

### DIFF
--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -30,7 +30,6 @@ def load_current_resource
   if vp.stdout.include?(new_resource.plugin_name)
     @current_resource.installed(true)
     installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }
-    @current_resource.installed_version = installed_line.split('(')[1].split(')')[0]
     @current_resource.installed_version(installed_line.gsub(/[\(\)]/, ''))
   end
   @current_resource


### PR DESCRIPTION
Seems to me like this line is not need at all and besides that it's breaking the `install_plugins` recipe.

The line was inserted at https://github.com/jtimberman/vagrant-cookbook/commit/802fccf8d451a48e302e08e82441795d9833c175
(which caused no harm)

And later changed at https://github.com/jtimberman/vagrant-cookbook/commit/cbecfaa9f0703aecb5e7ee3fa2a125b554cea9e0
(which broke things)

This intends to fix #32 