### PR TITLE
Support installing plugin from custom source

### DIFF
--- a/recipes/install_plugins.rb
+++ b/recipes/install_plugins.rb
@@ -21,6 +21,7 @@ node['vagrant']['plugins'].each do |plugin|
     vagrant_plugin plugin['name'] do
       user node['vagrant']['user']
       version plugin['version']
+      source  plugin['source']
     end
 
   else


### PR DESCRIPTION
The `vagrant_plugin` provider supports installing from a custom source. This PR adds that possibility to the `install_plugins` recipe