### PR TITLE
Fix issue 32 :: Properly parse installed vagrant plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ for `vagrant_plugin`.
 * Add Rakefile for testing/style checks.
 * Fix idempotency when installing Vagrant Windows package.
 * Bump default Vagrant version to 1.7.4
+* #32 Properly parse existing vagrant plugins in plugins provider.
 
 ## 0.3.1:
 

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -31,8 +31,7 @@ def load_current_resource
     @current_resource.installed(true)
     installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }
     installed_version = installed_line.split('(')[1].split(')')[0]
-    # installed_version should not include ", system"
-    @current_resource.installed_version(installed_version.gsub(/, system/, ''))
+    @current_resource.installed_version(installed_version)
   end
   @current_resource
 end

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -30,8 +30,9 @@ def load_current_resource
   if vp.stdout.include?(new_resource.plugin_name)
     @current_resource.installed(true)
     installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }
-    @current_resource.installed_version = installed_line.split('(')[1].split(')')[0]
-    @current_resource.installed_version(installed_line.gsub(/[\(\)]/, ''))
+    installed_version = installed_line.split('(')[1].split(')')[0]
+    # installed_version should not include ", system"
+    @current_resource.installed_version(installed_version.gsub(/, system/, ''))
   end
   @current_resource
 end

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -30,8 +30,7 @@ def load_current_resource
   if vp.stdout.include?(new_resource.plugin_name)
     @current_resource.installed(true)
     installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }
-    installed_version = installed_line.split('(')[1].split(')')[0]
-    @current_resource.installed_version(installed_version)
+    @current_resource.installed_version(installed_line.split('(')[1].split(')')[0])
   end
   @current_resource
 end


### PR DESCRIPTION
This PR addresses the bug described in ISSUE #32.  The existing plugin provider does not properly parse the installed vagrant plugins.  I am still unsure if the parsing code should be concerned with properly parsing the system vagrant plugins such as:
```
vagrant-share (1.1.4, system)
```

If so, we probably need to include a `gsub` or another `split(',')` call before calling `@current_resource.installed_version` setter.

This PR is an alternative to https://github.com/jtimberman/vagrant-cookbook/pull/40.  I believe this PR#40 will not properly parse output (it will only remove parentheses) 
