### PR TITLE
Miguelaferreira patch 1 - `install_plugins` recipe now accepts source or sources for each plugin to install from.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ unavailable. You can override `node['vagrant']['url']` and
 location.
 * Fix idempotency when installing Vagrant Windows package.
 * Refactor Vagrant::Helpers and add test coverage
+* `install_plugins` recipe now accepts source or sources for each plugin to install from.
 
 ### Dev environment changes
 * Add ChefSpec [Custom Matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers)

--- a/README.md
+++ b/README.md
@@ -60,10 +60,20 @@ The following attributes are optional.
 
 * `node['vagrant']['plugins']` - A array of plugins. The elements in
   the array can be a string or a hash. String elements should be the
-  names of plugins to install. Hash elements should have two keys,
-  "name" and "version", for the plugin name and its version to
-  install. This is used by the `vagrant_plugin` resource in the
-  `install_plugins` recipe.
+  names of plugins to install. Hash elements should have two or three key/value
+  pairs for each plugin: "name", "version", and "source".
+  This is used by the `vagrant_plugin` resource in the `install_plugins` recipe.
+
+  Use it like this:
+```ruby
+    node['vagrant']['plugins'] = [
+      { name: 'vagrant_plugin_1', version: '1.0.0',
+        source: %w(https://vagrant.example.com/my_plugin file://my_plugin)
+      },
+      { name: 'vagrant_plugin_2', version: '2.0.0' }
+    ]
+```
+
 * `node['vagrant']['user']` - A user that is used to automatically install plugins as for the `node['vagrant']['plugins']` attribute.
 
 # Resources

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -23,10 +23,11 @@ use_inline_resources if defined?(:use_inline_resources)
 
 def load_current_resource
   @current_resource = Chef::Resource::VagrantPlugin.new(new_resource)
-  vp = shell_out('vagrant plugin list',                                          user: run_as_user,
-                                                                                 env: {
-                                                                                   'VAGRANT_HOME' => vagrant_home
-                                                                                 })
+  vp = shell_out('vagrant plugin list',
+                  user: run_as_user,
+                  env: { 'VAGRANT_HOME' => vagrant_home }
+                )
+
   if vp.stdout.include?(new_resource.plugin_name)
     @current_resource.installed(true)
     installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }

--- a/recipes/install_plugins.rb
+++ b/recipes/install_plugins.rb
@@ -19,15 +19,15 @@ node['vagrant']['plugins'].each do |plugin|
   if plugin.respond_to?(:keys)
 
     vagrant_plugin plugin['name'] do
-      user node['vagrant']['user']
-      version plugin['version']
-      source  plugin['source']
+      user node['vagrant']['user'] if node['vagrant']['user']
+      version plugin['version'] if plugin['version']
+      sources plugin['source'] if plugin['source']
     end
 
   else
 
     vagrant_plugin plugin do
-      user node['vagrant']['user']
+      user node['vagrant']['user'] if node['vagrant']['user']
     end
 
   end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -24,4 +24,4 @@ attribute :version, kind_of: [String]
 attribute :installed, kind_of: [TrueClass, FalseClass]
 attribute :installed_version, kind_of: [String]
 attribute :user, kind_of: [String], default: nil
-attribute :sources, kind_of: [String, Array], default: nil
+attribute :sources, kind_of: [String, Array], default: ''

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -24,4 +24,4 @@ attribute :version, kind_of: [String]
 attribute :installed, kind_of: [TrueClass, FalseClass]
 attribute :installed_version, kind_of: [String]
 attribute :user, kind_of: [String], default: nil
-attribute :sources, kind_of: [String, Array], default: ''
+attribute :sources, kind_of: [String, Array], default: nil

--- a/spec/unit/recipes/install_plugins_spec.rb
+++ b/spec/unit/recipes/install_plugins_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe 'vagrant::install_plugins' do
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new(
+      platform: 'ubuntu',
+      version: '14.04',
+      file_cache_path: '/var/tmp'
+    )
+  end
+
+  it 'with no vagrant user specified, installs an array of plugins' do
+    chef_run.node.set['vagrant']['plugins'] = %w(vagrant-omnibus vagrant-aws)
+    chef_run.converge(described_recipe)
+    expect(chef_run).to install_vagrant_plugin('vagrant-omnibus')
+    expect(chef_run).to install_vagrant_plugin('vagrant-aws')
+  end
+
+  it 'with a vagrant user specified, installs a single plugin' do
+    chef_run.node.set['vagrant']['user'] = 'my_user'
+    chef_run.node.set['vagrant']['plugins'] = %w(vagrant-omnibus)
+    chef_run.converge(described_recipe)
+    expect(chef_run).to install_vagrant_plugin('vagrant-omnibus').with(
+      user: 'my_user'
+    )
+  end
+
+  it 'with a hash specifying a plugin name, version, and source' do
+    chef_run.node.set['vagrant']['user'] = 'my_user'
+    chef_run.node.set['vagrant']['plugins'] = [
+      { name: 'vagrant_plugin_1', version: '1.0.0',
+        source: %w(https://vagrant.example.com/my_plugin file://my_plugin)
+      },
+      { name: 'vagrant_plugin_2', version: '2.0.0' }
+    ]
+    chef_run.converge(described_recipe)
+
+    expect(chef_run).to install_vagrant_plugin('vagrant_plugin_1').with(
+      user: 'my_user',
+      version: '1.0.0',
+      sources: %w(https://vagrant.example.com/my_plugin file://my_plugin)
+    )
+    expect(chef_run).to install_vagrant_plugin('vagrant_plugin_2').with(
+      user: 'my_user',
+      version: '2.0.0'
+    )
+  end
+
+  it 'with a hash specifying a plugin name' do
+    chef_run.node.set['vagrant']['plugins'] = [{ name: 'my_plugin_without_version' }]
+    chef_run.converge(described_recipe)
+
+    expect(chef_run).to install_vagrant_plugin('my_plugin_without_version')
+  end
+end


### PR DESCRIPTION
`install_plugins` recipe now accepts source or sources for each plugin to install from.

@miguelaferreira @jtimberman can you review? I added ChefSpec coverage for the `install_plugins` recipe, including specifying a custom install source for each plugin.

This code has unit test coverage and all tests pass. However, it doesn't have integration tests for testing installing a vagrant plugin from a custom source. 

@miguelaferreira do you have a recommended vagrant plugin from a custom source (https://) you can test with? I'd like to hear back from you before we merge this change.

Specifically, I'd like to hear from you what happens if you have an array of plugins to install using the `install_plugins` recipe, of which the first plugin uses a custom source and the remaining plugins *don't* use a custom source. This will test if specifying a custom source for a plugin will break later plugin installs which don't use custom sources.

Also, if you can provide a good example of a vagrant plugin only available from a custom source, we will be able to write a ServerSpec or InSpec integration test using that.