### PR TITLE
Fix vagrant_plugin resource on Windows

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,7 @@ platforms:
 - name: macosx-10.10
   driver:
     box: chef/macosx-10.10
+- name: win81x64-enterprise
 
 suites:
 - name: debian
@@ -25,6 +26,7 @@ suites:
   excludes:
     - centos-7.1
     - macosx-10.10
+    - win81x64-enterprise
   attributes:
     vagrant:
       plugins:
@@ -36,6 +38,7 @@ suites:
   excludes:
     - ubuntu-14.04
     - macosx-10.10
+    - win81x64-enterprise
   attributes:
     vagrant:
       plugins:
@@ -47,7 +50,16 @@ suites:
   excludes:
     - ubuntu-14.04
     - centos-7.1
+    - win81x64-enterprise
   attributes:
     vagrant:
       plugins:
         - vagrant-omnibus
+
+- name: windows
+  run_list:
+    - recipe[test::windows_vagrant_plugin]
+  excludes:
+    - ubuntu-14.04
+    - centos-7.1
+    - macosx-10.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ unavailable. You can override `node['vagrant']['url']` and
 location.
 * Fix idempotency when installing Vagrant Windows package.
 * Refactor Vagrant::Helpers and add test coverage
+* `vagrant_plugin` resource correctly installs vagrant plugins as another user on Windows.
+* Refactor LWRP and add unit tests.
 
 ### Dev environment changes
 * Add ChefSpec [Custom Matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,12 @@ default_version = '1.7.4'
 default['vagrant']['version']     = default_version
 default['vagrant']['msi_version'] = default_version
 
+# the URL and checksum are calculated from the package version by helper methods
+# in the recipe if you# don't override them in a wrapper cookbook
 default['vagrant']['url']         = nil
 default['vagrant']['checksum']    = nil
+
 default['vagrant']['plugins']     = []
 default['vagrant']['user']        = nil
+# password is required on Windows if you want to install plugins as another user
+default['vagrant']['password']    = nil

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -70,27 +70,4 @@ module Vagrant
   end
 end
 
-def vagrant_get_home(user)
-  begin
-    # Attempting to get the $HOME of `user`
-    Chef::Log.debug("Attempting to get $HOME of #{user}")
-    home = Etc.getpwnam(user).dir
-  rescue ArgumentError
-    begin
-      # Could not look up `user`, seeing if Chef knows about a
-      # user[`user`] resource
-      Chef::Log.debug("Couldn't find `#{user}`, looking for a resource")
-      home = run_context.resource_collection.find("user[#{user}]").home
-    rescue Chef::Exceptions::ResourceNotFound
-      # Chef does not know about a user[`user`] resource, and that
-      # user does not exist on the system, try using the $HOME of the
-      # user running Chef
-      Chef::Log.debug("No user found, using running process uid, `#{Process.uid}`")
-      home = Etc.getpwuid(Process.uid).dir
-    end
-  end
-
-  home
-end
-
 Chef::Recipe.send(:include, Vagrant::Helpers)

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -1,0 +1,102 @@
+require 'chef/mixin/shell_out'
+
+module Vagrant
+  class UserNotFoundError < ArgumentError
+  end
+
+  class Plugin
+    include Chef::Mixin::ShellOut
+
+    attr_reader :plugin_name, :username, :password
+
+    def windows?
+      @is_windows
+    end
+
+    def initialize(plugin_name, is_windows, username: nil, password: nil)
+      @plugin_name = plugin_name
+      @is_windows = is_windows
+      @username = username
+      @password = password
+    end
+
+    # Searches for an installed Vagrant plugin
+    # @param name [String] name of the plugin to find
+    # @param options [Hash] { username, password, vagrant_home }
+    # @return [String] version of installed plugin, e.g. '1.23.34'
+    def installed_version
+      begin
+        list = vagrant_plugin_list
+      rescue UserNotFoundError
+        # when a user is not found, they can't possibly have any plugins
+        return nil
+      end
+      plugin_line = find_plugin_line(list)
+      extract_version_from(plugin_line)
+    end
+
+    def install(version = nil, sources = [])
+      vagrant_plugin_install = "vagrant plugin install #{plugin_name}"
+      vagrant_plugin_install << " --plugin-version #{version}" if version
+
+      sources.each do |source|
+        vagrant_plugin_install << " --plugin-source #{source}"
+      end
+
+      execute_cli vagrant_plugin_install
+    end
+
+    def uninstall
+      execute_cli "vagrant plugin uninstall #{plugin_name}"
+    end
+
+    private
+
+    def vagrant_plugin_list
+      cmd = execute_cli('vagrant plugin list')
+      cmd.stdout
+    end
+
+    def find_plugin_line(plugin_list_output)
+      lines = plugin_list_output.split(/\R/)
+      lines.find { |plugin| plugin =~ /#{plugin_name}\s\(/ }
+    end
+
+    def extract_version_from(plugin_line)
+      semver = /\s\((\d+\.\d+\.\d+)/ # =>  '1.12.34'
+
+      version = semver.match(plugin_line)
+      version[1] unless version.nil?
+    end
+
+    def execute_cli(command)
+      shell_out!(
+        command,
+        user: username,
+        password: password, # required on Windows
+        env: { 'VAGRANT_HOME' => vagrant_home }
+      )
+    end
+
+    def vagrant_home
+      user_home_dir = home_dir
+      ::File.join(user_home_dir, '.vagrant.d') unless user_home_dir.nil?
+    end
+
+    def home_dir
+      return Dir.home unless username
+
+      # Dir.home(user) raises ArgumentError: user `user` doesn't exist
+      # on Windows so we must workaround for now.
+      if windows?
+        "C:/Users/#{username}" if Dir.exist?("C:/Users/#{username}")
+      else
+        begin
+          Dir.home(username)
+        rescue ArgumentError
+          raise UserNotFoundError
+        end
+      end
+    end
+  end
+end

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -21,16 +21,6 @@ def whyrun_supported?
   true
 end
 
-def plugin
-  is_windows = node['platform_family'] == 'windows'
-  @plugin ||= Vagrant::Plugin.new(
-    new_resource.plugin_name,
-    is_windows,
-    username: new_resource.user,
-    password: new_resource.password
-  )
-end
-
 def load_current_resource
   @current_resource = Chef::Resource::VagrantPlugin.new(new_resource)
 
@@ -58,6 +48,18 @@ end
 
 action :uninstall do
   uninstall
+end
+
+private
+
+def plugin
+  is_windows = node['platform_family'] == 'windows'
+  @plugin ||= Vagrant::Plugin.new(
+    new_resource.plugin_name,
+    is_windows,
+    username: new_resource.user,
+    password: new_resource.password
+  )
 end
 
 def uninstall

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -14,94 +14,66 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-require 'etc'
-require 'chef/mixin/shell_out'
-include Chef::Mixin::ShellOut
-
 use_inline_resources if defined?(:use_inline_resources)
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+def plugin
+  is_windows = node['platform_family'] == 'windows'
+  @plugin ||= Vagrant::Plugin.new(
+    new_resource.plugin_name,
+    is_windows,
+    username: new_resource.user,
+    password: new_resource.password
+  )
+end
 
 def load_current_resource
   @current_resource = Chef::Resource::VagrantPlugin.new(new_resource)
-  vp = shell_out('vagrant plugin list',                                          user: run_as_user,
-                                                                                 env: {
-                                                                                   'VAGRANT_HOME' => vagrant_home
-                                                                                 })
-  if vp.stdout.include?(new_resource.plugin_name)
-    @current_resource.installed(true)
-    installed_line = vp.stdout.split("\n").detect { |line| line.include? new_resource.plugin_name }
-    @current_resource.installed_version = installed_line.split('(')[1].split(')')[0]
-    @current_resource.installed_version(installed_line.gsub(/[\(\)]/, ''))
+
+  installed_version = plugin.installed_version
+
+  if installed_version
+    current_resource.installed(true)
+    current_resource.installed_version(installed_version)
   end
-  @current_resource
+
+  current_resource
 end
 
 action :install do
-  unless installed?
-    plugin_args = ''
-    plugin_args += "--plugin-version #{new_resource.version}" if new_resource.version
-
-    unless new_resource.sources.empty?
-      sources = Array(new_resource.sources)
-      sources.each do |source|
-        plugin_args += " --plugin-source #{source}"
-      end
-    end
-
-    execute "installing vagrant plugin #{new_resource.plugin_name}" do
-      command "vagrant plugin install #{new_resource.plugin_name} #{plugin_args}"
-      user new_resource.user
-      environment 'VAGRANT_HOME' => vagrant_home
+  unless target_version_installed?
+    converge_by("Installing Vagrant plugin: #{new_resource.name} #{new_resource.version}") do
+      plugin.install(new_resource.version, Array(new_resource.sources))
     end
   end
 end
 
 action :remove do
-  uninstall if @current_resource.installed
+  uninstall
 end
 
 action :uninstall do
-  uninstall if @current_resource.installed
+  uninstall
 end
 
 def uninstall
-  execute "vagrant plugin uninstall #{new_resource.plugin_name}" do
-    user new_resource.user
-    environment 'VAGRANT_HOME' => vagrant_home
-  end
-end
-
-def run_as_user
-  case new_resource.user
-  when String
-    Chef::Log.debug("I found a string for `#{new_resource.user}`")
-    new_resource.user
-  when NilClass
-    begin
-      Chef::Log.debug("I'm searching for a resource user[#{new_resource.user}]")
-      run_context.resource_collection.find("user[#{new_resource.user}]").username
-    rescue ArgumentError
-      Chef::Log.debug("Trying to find the user by the process UID #{Process.uid}")
-      Etc.getpwuid(Process.uid).name
+  if current_resource.installed
+    converge_by("Uninstalling Vagrant plugin: #{new_resource.name} #{new_resource.version}") do
+      plugin.uninstall
     end
   end
 end
 
-def vagrant_home
-  ::File.join(vagrant_get_home(run_as_user), '.vagrant.d')
-end
-
-def installed?
-  @current_resource.installed && version_match
-end
-
 def version_match
-  # if the version is specified, we need to check if it matches what
-  # is installed already
-  if new_resource.version
-    @current_resource.installed_version == "#{new_resource.plugin_name} #{new_resource.version}"
-  else
-    # the version matches otherwise because it's installed
-    true
-  end
+  return true unless new_resource.version
+
+  new_resource.version == current_resource.installed_version
+end
+
+def target_version_installed?
+  current_resource.installed && version_match
 end

--- a/recipes/install_plugins.rb
+++ b/recipes/install_plugins.rb
@@ -17,16 +17,15 @@
 
 node['vagrant']['plugins'].each do |plugin|
   if plugin.respond_to?(:keys)
-
     vagrant_plugin plugin['name'] do
-      user node['vagrant']['user']
-      version plugin['version']
+      user node['vagrant']['user'] if node['vagrant']['user']
+      password node['vagrant']['password'] if node['vagrant']['password']
+      version plugin['version'] if plugin['version']
     end
-
   else
-
     vagrant_plugin plugin do
-      user node['vagrant']['user']
+      user node['vagrant']['user'] if node['vagrant']['user']
+      password node['vagrant']['password'] if node['vagrant']['password']
     end
 
   end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -24,4 +24,5 @@ attribute :version, kind_of: [String]
 attribute :installed, kind_of: [TrueClass, FalseClass]
 attribute :installed_version, kind_of: [String]
 attribute :user, kind_of: [String], default: nil
-attribute :sources, kind_of: [String, Array], default: ''
+attribute :password, kind_of: String, default: nil
+attribute :sources, kind_of: [String, Array], default: nil

--- a/spec/support/shared_mocks.rb
+++ b/spec/support/shared_mocks.rb
@@ -20,29 +20,3 @@ RSpec.shared_context 'mock vagrant_sha256sum' do
     end
   end
 end
-
-RSpec.shared_context 'mock vagrant_plugin_list' do
-  before(:context) do
-    RSpec.configure do |config|
-      config.mock_with :rspec do |mocks|
-        @vpd_setting = mocks.verify_partial_doubles?
-        mocks.verify_partial_doubles = false
-      end
-    end
-  end
-
-  let(:windows_plugin_list) { "simple-plugin (0.1.0, system)\r\ntwo-digit-minor (1.12.34)\r\nvagrant-foobar (2.3.4)" }
-  let(:unix_plugin_list) { windows_plugin_list.gsub(/\r\n/, "\n") }
-
-  before(:example) do
-    allow_any_instance_of(Chef::Provider).to receive(:vagrant_plugin_list).and_return(unix_plugin_list)
-  end
-
-  after(:context) do
-    RSpec.configure do |config|
-      config.mock_with :rspec do |mocks|
-        mocks.verify_partial_doubles = @vpd_setting
-      end
-    end
-  end
-end

--- a/spec/support/shared_mocks.rb
+++ b/spec/support/shared_mocks.rb
@@ -20,3 +20,29 @@ RSpec.shared_context 'mock vagrant_sha256sum' do
     end
   end
 end
+
+RSpec.shared_context 'mock vagrant_plugin_list' do
+  before(:context) do
+    RSpec.configure do |config|
+      config.mock_with :rspec do |mocks|
+        @vpd_setting = mocks.verify_partial_doubles?
+        mocks.verify_partial_doubles = false
+      end
+    end
+  end
+
+  let(:windows_plugin_list) { "simple-plugin (0.1.0, system)\r\ntwo-digit-minor (1.12.34)\r\nvagrant-foobar (2.3.4)" }
+  let(:unix_plugin_list) { windows_plugin_list.gsub(/\r\n/, "\n") }
+
+  before(:example) do
+    allow_any_instance_of(Chef::Provider).to receive(:vagrant_plugin_list).and_return(unix_plugin_list)
+  end
+
+  after(:context) do
+    RSpec.configure do |config|
+      config.mock_with :rspec do |mocks|
+        mocks.verify_partial_doubles = @vpd_setting
+      end
+    end
+  end
+end

--- a/spec/unit/libraries/plugin_cli_spec.rb
+++ b/spec/unit/libraries/plugin_cli_spec.rb
@@ -1,0 +1,103 @@
+require 'simplecov'
+SimpleCov.start
+
+require_relative '../../../libraries/plugin'
+
+RSpec.describe Vagrant::Plugin do
+  let(:windows_user) { { username: 'my_user', password: 'my_password' } }
+  let(:unix_user) { { username: 'my_user' } }
+
+  let(:windows_plugin_list) { "simple-plugin (0.1.0, system)\r\ntwo-digit-minor (1.12.34)\r\nvagrant-foobar (2.3.4)" }
+  let(:unix_plugin_list) { windows_plugin_list.gsub(/\r\n/, "\n") }
+
+  def plugin_cli_with_vpl_mocked(name, is_windows, options = {})
+    cli = Vagrant::Plugin.new(name, is_windows, options)
+    list = cli.windows? ? windows_plugin_list : unix_plugin_list
+    allow(cli).to receive(:vagrant_plugin_list).and_return(list)
+    cli
+  end
+
+  def windows_cli_with_vpl_mocked(name, options = {})
+    plugin_cli_with_vpl_mocked(name, true, options)
+  end
+
+  def unix_cli_with_vpl_mocked(name, options = {})
+    plugin_cli_with_vpl_mocked(name, false, options)
+  end
+
+  describe '#version' do
+    context 'On Windows' do
+      it 'given a non-installed plugin, returns nil' do
+        version = windows_cli_with_vpl_mocked('non-existent').installed_version
+        expect(version).to be_nil
+      end
+
+      it 'given an installed plugin name, returns the version' do
+        version = windows_cli_with_vpl_mocked('simple-plugin').installed_version
+        expect(version).to eq '0.1.0'
+      end
+
+      it 'given a cli configured with a plugin that has a 2-digit minor version, returns the version' do
+        version = windows_cli_with_vpl_mocked('two-digit-minor').installed_version
+        expect(version).to eq '1.12.34'
+      end
+
+      it 'given a cli configured with a user to impersonate, returns the correct version' do
+        version = windows_cli_with_vpl_mocked('vagrant-foobar', windows_user).installed_version
+        expect(version).to eq '2.3.4'
+      end
+    end
+
+    context 'On Unix' do
+      it 'given a cli configured with a non-installed plugin, returns nil' do
+        version = unix_cli_with_vpl_mocked('non-existent').installed_version
+        expect(version).to be_nil
+      end
+
+      it 'given a cli configured with a name, returns the version' do
+        version = unix_cli_with_vpl_mocked('simple-plugin').installed_version
+        expect(version).to eq '0.1.0'
+      end
+    end
+  end
+
+  describe '#install' do
+    it 'given no version or source, executes vagrant plugin install' do
+      cli = Vagrant::Plugin.new('simple-plugin', true)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin install simple-plugin')
+      cli.install
+    end
+
+    it 'given a version, executes vagrant plugin install targetting the version' do
+      cli = Vagrant::Plugin.new('version-plugin', false)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin install version-plugin --plugin-version 0.1.0')
+      cli.install('0.1.0')
+    end
+
+    it 'given a source, executes vagrant plugin install from the source' do
+      cli = Vagrant::Plugin.new('source-plugin', true)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin install source-plugin --plugin-source https://in-house.server.com/')
+      cli.install(nil, ['https://in-house.server.com/'])
+    end
+
+    it 'given two sources, executes vagrant plugin install with both sources' do
+      cli = Vagrant::Plugin.new('sources-plugin', false)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin install sources-plugin --plugin-source https://in-house.server.com/ --plugin-source https://alternate.source.com')
+      cli.install(nil, ['https://in-house.server.com/', 'https://alternate.source.com'])
+    end
+
+    it 'given both a version and a source, executes vagrant plugin install with both constraints' do
+      cli = Vagrant::Plugin.new('version-plugin', true)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin install version-plugin --plugin-version 0.1.0 --plugin-source https://in-house.server.com/')
+      cli.install('0.1.0', ['https://in-house.server.com/'])
+    end
+  end
+
+  describe '#uninstall' do
+    it 'executes vagrant plugin uninstall' do
+      cli = Vagrant::Plugin.new('byebye-plugin', true)
+      expect(cli).to receive(:execute_cli).with('vagrant plugin uninstall byebye-plugin')
+      cli.uninstall
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -21,9 +21,7 @@ include_recipe 'build-essential'
 include_recipe 'vagrant'
 
 # How meta...
-vagrant_plugin 'vagrant-aws' do
-  user 'vagrant'
-end
+vagrant_plugin 'vagrant-aws'
 
 # A user that doesn't exist...
 donut_home = case node['os']

--- a/test/fixtures/cookbooks/test/recipes/windows_vagrant_plugin.rb
+++ b/test/fixtures/cookbooks/test/recipes/windows_vagrant_plugin.rb
@@ -1,0 +1,3 @@
+include_recipe 'vagrant'
+
+vagrant_plugin 'vagrant-ohai'


### PR DESCRIPTION
Rewrite vagrant_plugin provider. Split all functionality for vagrant plugin
install/uninstall into a separate class to separate concerns. This allows
for easy unit testing of vagrant plugin commands which interact with the
system.

Fixes #42
Fixes #32