### PR TITLE
Release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Vagrant Cookbook Changelog
 
-## Unreleased
+## 0.4.0 - December 21, 2015
 
 * Bump default Vagrant version to 1.7.4
 * Cookbook no longer fails during compile phase if https://dl.bintray.com is
@@ -12,7 +12,7 @@ location.
 * `vagrant_plugin` resource correctly installs vagrant plugins as another user on Windows.
 * Refactor LWRP and add unit tests.
 
-### Dev environment changes
+#### Dev environment changes
 * Add ChefSpec [Custom Matchers](https://github.com/sethvargo/chefspec#packaging-custom-matchers)
 for `vagrant_plugin`.
 * Add Rakefile for testing/style checks.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ See the attribute tables above.
 # License and Authors
 
 * Author:: Joshua Timberman <opensource@housepub.org>
+* Author:: Doug Ireton <doug.ireton@nordstrom.com>
 * Copyright (c) 2013-2014, Joshua Timberman
 
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer_email 'cookbooks@housepub.org'
 license          'Apache 2.0'
 description      'Installs Vagrant and provides a vagrant_plugin LWRP for installing Vagrant plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.3.1'
+version          '0.4.0'
 
 source_url 'https://github.com/jtimberman/vagrant-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/jtimberman/vagrant-cookbook/issues' if respond_to?(:issues_url)

--- a/spec/unit/libraries/plugin_spec.rb
+++ b/spec/unit/libraries/plugin_spec.rb
@@ -1,6 +1,3 @@
-require 'simplecov'
-SimpleCov.start
-
 require_relative '../../../libraries/plugin'
 
 RSpec.describe Vagrant::Plugin do


### PR DESCRIPTION
Bump default Vagrant version to 1.7.4

Cookbook no longer fails during compile phase if https://dl.bintray.com is
unavailable. You can override `node['vagrant']['url']` and
`node['vagrant']['checksum']` if you need to download Vagrant from a different
location.

Fix idempotency when installing Vagrant Windows package.
Refactor Vagrant::Helpers and add test coverage

`vagrant_plugin` resource correctly installs vagrant plugins as another user on Windows.

Refactor vagrant_plugin LWRP and add unit tests.