### PR TITLE
Update to new hashicorp.com URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Vagrant Cookbook Changelog
 
+## Unreleased
+
+* Change the base URL for downloads to the new hashicorp.com URLs to support Vagrant 1.8+
+
 ## 0.4.0 - December 21, 2015
 
 * Bump default Vagrant version to 1.7.4

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,7 +23,7 @@ require 'open-uri'
 module Vagrant
   module Helpers
     def vagrant_package_uri
-      URI.join(vagrant_base_uri, package_name).to_s
+      URI.join(vagrant_base_uri, "#{package_version}/#{package_name}").to_s
     end
 
     def vagrant_sha256sum
@@ -34,7 +34,7 @@ module Vagrant
     private
 
     def vagrant_base_uri
-      'https://dl.bintray.com/mitchellh/vagrant/'
+      'https://releases.hashicorp.com/vagrant/'
     end
 
     def package_name
@@ -60,7 +60,7 @@ module Vagrant
     end
 
     def fetch_platform_checksums_for_version
-      checksums_url = URI.join(vagrant_base_uri, "#{package_version}_SHA256SUMS?direct")
+      checksums_url = URI.join(vagrant_base_uri, "#{package_version}/#{package_version}_SHA256SUMS?direct")
       open(checksums_url).readlines
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -23,7 +23,7 @@ require 'open-uri'
 module Vagrant
   module Helpers
     def vagrant_package_uri
-      URI.join(vagrant_base_uri, "#{package_version}/#{package_name}").to_s
+      "#{vagrant_base_uri}#{package_version}/#{package_name}"
     end
 
     def vagrant_sha256sum
@@ -60,7 +60,7 @@ module Vagrant
     end
 
     def fetch_platform_checksums_for_version
-      checksums_url = URI.join(vagrant_base_uri, "#{package_version}/#{package_version}_SHA256SUMS?direct")
+      checksums_url = "#{vagrant_base_uri}#{package_version}/#{package_version}_SHA256SUMS?direct")
       open(checksums_url).readlines
     end
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,7 +60,7 @@ module Vagrant
     end
 
     def fetch_platform_checksums_for_version
-      checksums_url = "#{vagrant_base_uri}#{package_version}/#{package_version}_SHA256SUMS?direct")
+      checksums_url = "#{vagrant_base_uri}#{package_version}/#{package_version}_SHA256SUMS?direct"
       open(checksums_url).readlines
     end
 

--- a/spec/unit/libraries/helpers_spec.rb
+++ b/spec/unit/libraries/helpers_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Vagrant::Helpers do
     allow(my_recipe).to receive(:package_version).and_return('1.7.4')
     allow(my_recipe).to receive(:package_extension).and_return('.dmg')
 
-    expect(my_recipe.vagrant_package_uri).to eq 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.dmg'
+    expect(my_recipe.vagrant_package_uri).to eq 'https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.dmg'
   end
 
   it 'returns the correct SHA256 checksum for the mac_os_x package' do

--- a/spec/unit/recipes/debian_spec.rb
+++ b/spec/unit/recipes/debian_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'vagrant::debian' do
 
   it 'downloads the package from the calculated URI' do
     expect(chef_run).to create_remote_file('/var/tmp/vagrant.deb').with(
-      source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.deb',
+      source: 'https://releases.hashicorp.com/vagrant/1.88.88/vagrant_1.88.88_x86_64.deb',
       checksum: 'abc123'
     )
   end

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'vagrant::mac_os_x' do
 
   it 'installs the downloaded package with the calculated source URI' do
     expect(chef_run).to install_dmg_package('Vagrant').with(
-      source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88.dmg'
+      source: 'https://releases.hashicorp.com/vagrant/1.88.88/vagrant_1.88.88.dmg'
     )
   end
 end

--- a/spec/unit/recipes/rhel_spec.rb
+++ b/spec/unit/recipes/rhel_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'vagrant::rhel' do
 
   it 'downloads the package from the calculated URI' do
     expect(chef_run).to create_remote_file('/var/tmp/vagrant.rpm').with(
-      source: 'https://dl.bintray.com/mitchellh/vagrant/vagrant_1.88.88_x86_64.rpm'
+      source: 'https://releases.hashicorp.com/vagrant/1.88.88/vagrant_1.88.88_x86_64.rpm'
     )
   end
 

--- a/spec/unit/recipes/windows_spec.rb
+++ b/spec/unit/recipes/windows_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'vagrant::windows' do
 
     it "installs Vagrant version #{VAGRANT_DEFAULT_VERSION}" do
       expect(windows_node).to install_windows_package('Vagrant').with(
-        source: "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{VAGRANT_DEFAULT_VERSION}.msi",
+        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_DEFAULT_VERSION}/vagrant_#{VAGRANT_DEFAULT_VERSION}.msi",
         version: VAGRANT_DEFAULT_VERSION
       )
     end
@@ -50,7 +50,7 @@ RSpec.describe 'vagrant::windows' do
 
     it "installs Vagrant version #{VAGRANT_OVERRIDE_VERSION}" do
       expect(windows_node).to install_windows_package('Vagrant').with(
-        source: "https://dl.bintray.com/mitchellh/vagrant/vagrant_#{VAGRANT_OVERRIDE_VERSION}.msi",
+        source: "https://releases.hashicorp.com/vagrant/#{VAGRANT_OVERRIDE_VERSION}/vagrant_#{VAGRANT_OVERRIDE_VERSION}.msi",
         version: VAGRANT_OVERRIDE_VERSION
       )
     end


### PR DESCRIPTION
New versions of vagrant (1.8+) are available only under
https://releases.hashicorp.com/vagrant/ now, but older versions are also
supported at the new URLs. See https://www.vagrantup.com/downloads.html