### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Vagrant Cookbook Changelog
 
-## Unreleased
+## 0.4.1 - January 6, 2016
 
-* Change the base URL for downloads to the new hashicorp.com URLs to support Vagrant 1.8+
+* Hashicorp has moved Vagrant package downloads from bintray.com to hashicorp.com. Download Vagrant packages from new location.
 
 ## 0.4.0 - December 21, 2015
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer_email 'cookbooks@housepub.org'
 license          'Apache 2.0'
 description      'Installs Vagrant and provides a vagrant_plugin LWRP for installing Vagrant plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.0'
+version          '0.4.1'
 
 source_url 'https://github.com/jtimberman/vagrant-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/jtimberman/vagrant-cookbook/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Hashicorp has moved Vagrant package downloads from bintray.com to hashicorp.com.
Download Vagrant packages from new location.