### PR TITLE
FIX: Proper location of checksum file after move

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -60,7 +60,7 @@ module Vagrant
     end
 
     def fetch_platform_checksums_for_version
-      checksums_url = "#{vagrant_base_uri}#{package_version}/#{package_version}_SHA256SUMS?direct"
+      checksums_url = "#{vagrant_base_uri}#{package_version}/vagrant_#{package_version}_SHA256SUMS?direct"
       open(checksums_url).readlines
     end
 


### PR DESCRIPTION
For example:

https://releases.hashicorp.com/vagrant/1.8.1/vagrant_1.8.1_SHA256SUMS

not

https://releases.hashicorp.com/vagrant/1.8.1/1.8.1_SHA256SUMS (returns
403)