### PR TITLE
Release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Vagrant Cookbook Changelog
 
+## 0.4.2 - January 7, 2016
+
+* Fix regression in `fetch_platform_checksums_for_version` method. Release 0.4.1
+changed the checksums URL to the new Hashicorp location and introduced a regression.
+The `fetch_platform_checksums_for_version` method now returns the correct URL.
+
+Thanks to Jeff Bachtel for the PR.
+
 ## 0.4.1 - January 6, 2016
 
 * Hashicorp has moved Vagrant package downloads from bintray.com to hashicorp.com. Download Vagrant packages from new location.

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,7 +18,7 @@ maintainer_email 'cookbooks@housepub.org'
 license          'Apache 2.0'
 description      'Installs Vagrant and provides a vagrant_plugin LWRP for installing Vagrant plugins.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.4.1'
+version          '0.4.2'
 
 source_url 'https://github.com/jtimberman/vagrant-cookbook' if respond_to?(:source_url)
 issues_url 'https://github.com/jtimberman/vagrant-cookbook/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Fix regression in `fetch_platform_checksums_for_version` method. Release 0.4.1
changed the checksums URL to the new Hashicorp location and introduced a regression.
The `fetch_platform_checksums_for_version` method now returns the correct URL.

Thanks to Jeff Bachtel for the PR.