### PR TITLE
fixes #60

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,10 @@ platforms:
 - name: win81x64-enterprise
 
 suites:
-- name: debian
+<% %w(11 12).each do |version| %>
+- name: debian_chef<%= version %>
+  provisioner:
+    require_chef_omnibus: <%= version %>
   run_list:
     - recipe[test]
   excludes:
@@ -32,7 +35,9 @@ suites:
       plugins:
         - vagrant-omnibus
 
-- name: rhel
+- name: rhel_chef<%= version %>
+  provisioner:
+    require_chef_omnibus: <%= version %>
   run_list:
     - recipe[test]
   excludes:
@@ -44,7 +49,9 @@ suites:
       plugins:
         - vagrant-omnibus
 
-- name: osx
+- name: osx_chef<%= version %>
+  provisioner:
+    require_chef_omnibus: <%= version %>
   run_list:
     - recipe[test]
   excludes:
@@ -56,10 +63,13 @@ suites:
       plugins:
         - vagrant-omnibus
 
-- name: windows
+- name: windows_chef<%= version %>
+  provisioner:
+    require_chef_omnibus: <%= version %>
   run_list:
     - recipe[test::windows_vagrant_plugin]
   excludes:
     - ubuntu-14.04
     - centos-7.1
     - macosx-10.10
+<% end %>

--- a/libraries/plugin.rb
+++ b/libraries/plugin.rb
@@ -13,11 +13,11 @@ module Vagrant
       @is_windows
     end
 
-    def initialize(plugin_name, is_windows, username: nil, password: nil)
+    def initialize(plugin_name, is_windows, options = {})
       @plugin_name = plugin_name
       @is_windows = is_windows
-      @username = username
-      @password = password
+      @username = options.fetch(:username, nil)
+      @password = options.fetch(:password, nil)
     end
 
     # Searches for an installed Vagrant plugin


### PR DESCRIPTION
Updates the kitchen yaml so that both Chef 11 and 12 are tested.

Fixes the init in the plugin class to use Ruby 1.9 (aka Chef 11) compatible syntax.