### PR TITLE
added version to dpkg_package to resolve problem running debian cookb…

### DIFF
--- a/recipes/debian.rb
+++ b/recipes/debian.rb
@@ -28,4 +28,5 @@ end
 
 dpkg_package 'vagrant' do
   source "#{Chef::Config[:file_cache_path]}/vagrant.deb"
+  version node['vagrant']['version']
 end

--- a/spec/unit/recipes/debian_spec.rb
+++ b/spec/unit/recipes/debian_spec.rb
@@ -20,7 +20,8 @@ RSpec.describe 'vagrant::debian' do
 
   it 'installs the downloaded package' do
     expect(chef_run).to install_dpkg_package('vagrant').with(
-      source: '/var/tmp/vagrant.deb'
+      source: '/var/tmp/vagrant.deb',
+      version: '1.88.88'
     )
   end
 end


### PR DESCRIPTION
The debian recipe doesn't upgrade Vagrant if it is already installed, the dpkg_package statement is skipped as "up to date".
> 
==> default: Recipe: vagrant::debian
==> default:   
==> default: * remote_file[/var/chef/cache/vagrant.deb] action create
==> default: [2016-04-07T16:48:36+00:00] INFO: remote_file[/var/chef/cache/vagrant.deb] backed up to /var/chef/backup/var/chef/cache/vagrant.deb.chef-20160407164835.943916
==> default: [2016-04-07T16:48:36+00:00] INFO: remote_file[/var/chef/cache/vagrant.deb] updated file contents /var/chef/cache/vagrant.deb
==> default:     
==> default: - update content in file /var/chef/cache/vagrant.deb from 9d7f1c to ed0e1a
==> default:     
==> default: (file sizes exceed 10000000 bytes, diff output suppressed)
==> default: 
==> default: 
==> default: [2016-04-07T16:48:36+00:00] INFO: remote_file[/var/chef/cache/vagrant.deb] sending install action to dpkg_package[vagrant] (immediate)
==> default:   
==> default: * dpkg_package[vagrant] action install
==> default:  (up to date)
==> default:   
==> default: * dpkg_package[vagrant] action install
==> default:  (up to date)

I had Vagrant 1.7.2 installed on a Ubuntu 14.04 system.   I then attempted to upgrade Vagrant by setting the following attributes (in a wrapper cookbook) but the package install was skipped.

```
default['vagrant']['url'] = 'http://bpm-ci-repos:8650/downloads/vagrant/vagrant_1.8.1_x86_64.deb'
default['vagrant']['checksum'] = 'ed0e1ae0f35aecd47e0b3dfb486a230984a08ceda3b371486add4d42714a693d'
default['vagrant']['version'] = '1.8.1'
```

I added 'version' to the dpkg_package resource and the Vagrant package got updated correctly.
Thanks.
Rich.