### PR TITLE
Unlock constraint on windows cookbook

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -31,4 +31,4 @@ supports 'windows'
 supports 'mac_os_x'
 
 depends 'dmg', '>= 2.2.2'
-depends 'windows', '~> 1.38'
+depends 'windows', '>= 1.38'


### PR DESCRIPTION
Current constraint is pessimistic, and forbid upgrade to the newest version.
No breaking change is impacting the vagrant cookbook. It's safe to release
the constraint.

**Cc.** @aboten