### PR TITLE
Fix incompatibility with Chef 13

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ ClassLength:
   Enabled: false
 MethodLength:
   Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
 LineLength:
   Enabled: false
 PerceivedComplexity:

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -22,7 +22,7 @@ def whyrun_supported?
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::VagrantPlugin.new(new_resource)
+  @current_resource = Chef::Resource.resource_for_node(:vagrant_plugin, node).new(new_resource)
 
   installed_version = plugin.installed_version
 


### PR DESCRIPTION
Per the Chef 13 [release notes](https://docs.chef.io/release_notes.html)
LWRP resources no longer get constant names, resulting in this:

```
  * vagrant_plugin[vagrant-winrm] action install

    ================================================================================
    Error executing action `install` on resource 'vagrant_plugin[vagrant-winrm]'
    ================================================================================

    NameError
    ---------
    uninitialized constant Chef::Resource::VagrantPlugin
    Did you mean?  Vagrant
```

Signed-off-by: Jonathan Hartman <j@p4nt5.com>