### PR TITLE
The package extension for the vagrant package changed

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -47,7 +47,7 @@ module Vagrant
 
     def package_extension
       extension = value_for_platform_family(
-        'mac_os_x' => '.dmg',
+        'mac_os_x' =>  mac_os_x_extension,
         'windows' => '.msi',
         'debian' => '_x86_64.deb',
         %w(rhel suse fedora) => '_x86_64.rpm'
@@ -64,6 +64,11 @@ module Vagrant
 
     def extract_checksum(sha256sums)
       sha256sums.grep(/#{package_name}/)[0].split.first
+    end
+
+    def mac_os_x_extension
+      last_using_dmg = Gem::Version.new('1.9.2')
+      Gem::Version.new(package_version) > last_using_dmg ? '_x86_64.dmg' : '.dmg'
     end
   end
 end

--- a/spec/unit/recipes/mac_os_x_spec.rb
+++ b/spec/unit/recipes/mac_os_x_spec.rb
@@ -13,7 +13,23 @@ RSpec.describe 'vagrant::mac_os_x' do
 
   it 'installs the downloaded package with the calculated source URI' do
     expect(chef_run).to install_dmg_package('Vagrant').with(
-      source: 'https://releases.hashicorp.com/vagrant/1.88.88/vagrant_1.88.88.dmg'
+      source: 'https://releases.hashicorp.com/vagrant/1.88.88/vagrant_1.88.88_x86_64.dmg'
+    )
+  end
+
+  let(:chef_run_old) do
+    ChefSpec::SoloRunner.new(
+      platform: 'mac_os_x',
+      version: '10.10',
+      file_cache_path: '/var/tmp'
+    ) do |node|
+      node.normal['vagrant']['version'] = '1.9.1'
+    end.converge(described_recipe)
+  end
+
+  it 'installs an older vagrant package with the calculated source URI' do
+    expect(chef_run_old).to install_dmg_package('Vagrant').with(
+      source: 'https://releases.hashicorp.com/vagrant/1.9.1/vagrant_1.9.1.dmg'
     )
   end
 end


### PR DESCRIPTION
After version 1.9.2 the extension is _x86_64.dmg.  Should fix #77
